### PR TITLE
editor manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,25 @@ Les champs obligatoires sont :
 * Date d'entrée en vigueur
 * Date de révision
 
+## Roles 
 
+Il existe 3 rôles :
+- le rôle epfl-member 
+- le rôle editor
+- le rôle admin
+
+Lorsque l'utilisateur s'authenfie la 1ère fois à l'application polylex, on lui attribue automatiquement le rôle epfl-member.
+Avec ce rôle, l'utilisateur ne peut pour l'instant rien faire.
+
+Un utilisateur avec le rôle éditeur peut lister, créer, éditer, supprimer des lexes mais ne peut pas gérer les catégories, les sous-catégories et les responsables.
+
+L'admin peut tout faire. Il devrait avoir conscience des conséquences lors d'un changement sur les catégories, sous catégories et responsables.
+
+Cas d'utilisation n°1: Changement d'un responsable 
+Un responsable quitte l'EPFL. Un successeur doit "hériter" de tous ses lexes.
+
+Cas d'utilisation n°2: Gestion des catégories et sous-catégories
+Si on supprime une catégorie, il faut avoir conscience que tous les lexes liées à cette catégorie référenceront une catégorie qui n'existe plus.
 
 ## Déployer une nouvelle version sur l'environnement de test d'openshift
 

--- a/ansible/roles/epfl.polylex/vars/main.yml
+++ b/ansible/roles/epfl.polylex/vars/main.yml
@@ -6,7 +6,7 @@ polylex_route_name: polylex
 polylex_secret_name: "polylex"
 polylex_cname: "{{ 'polylex-admin.epfl.ch' if openshift_namespace == 'wwp' else 'polylex.128.178.222.83.nip.io' }}"
 polylex_deploy_name: polylex
-polylex_image_version: '0.0.3'
+polylex_image_version: '0.0.4'
 polylex_image_tag: 'epflidevelop/polylex:{{ polylex_image_version }}'
 polylex_db_name: "polylex"
 polylex_db_user: "polylex"

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -25,14 +25,26 @@ function prepareUpdateInsert(lex, action) {
     }
 
     // Check if LEX is unique
-    if (Lexes.findOne({lex: lex.lex})) {
-        throwMeteorError('lex', 'Ce LEX existe déjà');
-    } else {
-        // Check if LEX is format x.x.x or x.x.x.x
-        var lexRE = /^\d.\d.\d|\d.\d.\d.\d$/;
-        if (!lex.lex.match(lexRE)) {
-            throwMeteorError('lex', 'Le format d\'un LEX doit être x.x.x ou x.x.x.x');
+    if (action === 'update') {
+        let lexes = Lexes.find({lex:lex.lex});
+        if (lexes.count() > 1) {
+            throwMeteorError('lex', 'Ce LEX existe déjà !');
+        } else if (lexes.count() == 1) {
+            if (lexes.fetch()[0]._id != lex._id) {
+                throwMeteorError('lex', 'Ce LEX existe déjà !');
+            }
         }
+    } 
+    else {
+        if (Lexes.findOne({lex: lex.lex})) {
+            throwMeteorError('lex', 'Ce LEX existe déjà');
+        }
+    }
+    
+    // Check if LEX is format x.x.x or x.x.x.x
+    var lexRE = /^\d.\d.\d|\d.\d.\d.\d$/;
+    if (!lex.lex.match(lexRE)) {
+        throwMeteorError('lex', 'Le format d\'un LEX doit être x.x.x ou x.x.x.x');
     }
 
     // Check if responsible is empty
@@ -55,13 +67,13 @@ Meteor.methods({
 
         const canInsert = Roles.userIsInRole(
             this.userId,
-            ['admin'], 
+            ['admin', 'editor'], 
             Roles.GLOBAL_GROUP
         );
 
         if (! canInsert) {
             throw new Meteor.Error('unauthorized',
-              'Only admins can insert sites.');
+              'Only admins and editors can insert lexes.');
         }
         
         lexesSchema.validate(lex);
@@ -94,13 +106,13 @@ Meteor.methods({
 
         const canUpdate = Roles.userIsInRole(
             this.userId,
-            ['admin'], 
+            ['admin', 'editor'], 
             Roles.GLOBAL_GROUP
         );
 
         if (! canUpdate) {
             throw new Meteor.Error('unauthorized',
-              'Only admins can update sites.');
+              'Only admins and editors can update lexes.');
         }
 
         //console.log(lex);
@@ -139,13 +151,13 @@ Meteor.methods({
 
         const canRemove = Roles.userIsInRole(
             this.userId,
-            ['admin'], 
+            ['admin', 'editor'], 
             Roles.GLOBAL_GROUP
         );
 
         if (! canRemove) {
             throw new Meteor.Error('unauthorized',
-              'Only admins can remove sites.');
+              'Only admins and editors can remove lexes.');
         }
 
         check(lexId, String);

--- a/app/imports/ui/App.jsx
+++ b/app/imports/ui/App.jsx
@@ -13,23 +13,29 @@ class App extends React.Component {
   render() {
     
     let isAdmin;
+    let isEditor;
     
     if (this.props.currentUser === undefined) {
       return 'Loading';
 
     } else {
       isAdmin = Roles.userIsInRole(Meteor.userId(), 'admin', Roles.GLOBAL_GROUP);
+      isEditor = Roles.userIsInRole(Meteor.userId(), 'editor', Roles.GLOBAL_GROUP);
     }
 
     return (
       <Router>
         <div className="App container">
           <Header  />      
-          { isAdmin ?   
+          { isAdmin || isEditor ?   
             (<React.Fragment>
             <Route exact path="/" component={ List } />
             <Route exact path="/add" component={ Add } />
             <Route path="/edit/:_id" component={ Add } />
+            </React.Fragment>)
+           : null}
+          { isAdmin ?   
+            (<React.Fragment>
             <Route exact path="/admin" component={ Admin } />
             <Route exact path="/admin/users" component={ User } />
             </React.Fragment>)

--- a/app/imports/ui/lexes/Add.jsx
+++ b/app/imports/ui/lexes/Add.jsx
@@ -78,6 +78,7 @@ class Add extends React.Component {
         values, 
         (errors, lexId) => {
           if (errors) {
+            console.log(errors);
             let formErrors = {};
             errors.details.forEach(function(error) {
               formErrors[error.name] = error.message;                        

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -30,6 +30,7 @@ Meteor.startup(() => {
           );
 
           if (tequilaResponse.uniqueid == "188475") {
+            Roles.setUserRoles(tequilaResponse.uniqueid, ['editor'], Roles.GLOBAL_GROUP); 
             Roles.setUserRoles(tequilaResponse.uniqueid, ['admin'], Roles.GLOBAL_GROUP); 
           }
           


### PR DESCRIPTION
- Ajout du rôle Editor
- Un utilisateur avec le rôle éditeur peut lister, créer, éditer, supprimer des lexes mais ne peut pas gérer les catégories, les sous-catégories et les responsables.
Ainsi, c'est l'admin qui devra avoir conscience des relations avec Responsables et lexes ou encore entre catégorie et lexes pour gérer au mieux les évolutions.
