### PR TITLE
Update accounts-tequila package

### DIFF
--- a/ansible/roles/epfl.polylex/vars/main.yml
+++ b/ansible/roles/epfl.polylex/vars/main.yml
@@ -6,7 +6,7 @@ polylex_route_name: polylex
 polylex_secret_name: "polylex"
 polylex_cname: "{{ 'polylex-admin.epfl.ch' if openshift_namespace == 'wwp' else 'polylex.128.178.222.83.nip.io' }}"
 polylex_deploy_name: polylex
-polylex_image_version: '0.0.20'
+polylex_image_version: '0.0.21'
 polylex_image_tag: 'epflidevelop/polylex:{{ polylex_image_version }}'
 polylex_db_name: "polylex"
 polylex_db_user: "polylex"

--- a/ansible/roles/epfl.polylex/vars/main.yml
+++ b/ansible/roles/epfl.polylex/vars/main.yml
@@ -6,7 +6,7 @@ polylex_route_name: polylex
 polylex_secret_name: "polylex"
 polylex_cname: "{{ 'polylex-admin.epfl.ch' if openshift_namespace == 'wwp' else 'polylex.128.178.222.83.nip.io' }}"
 polylex_deploy_name: polylex
-polylex_image_version: '0.0.21'
+polylex_image_version: '0.0.22'
 polylex_image_tag: 'epflidevelop/polylex:{{ polylex_image_version }}'
 polylex_db_name: "polylex"
 polylex_db_user: "polylex"

--- a/ansible/roles/epfl.polylex/vars/main.yml
+++ b/ansible/roles/epfl.polylex/vars/main.yml
@@ -6,7 +6,7 @@ polylex_route_name: polylex
 polylex_secret_name: "polylex"
 polylex_cname: "{{ 'polylex-admin.epfl.ch' if openshift_namespace == 'wwp' else 'polylex.128.178.222.83.nip.io' }}"
 polylex_deploy_name: polylex
-polylex_image_version: '0.0.22'
+polylex_image_version: '0.0.23'
 polylex_image_tag: 'epflidevelop/polylex:{{ polylex_image_version }}'
 polylex_db_name: "polylex"
 polylex_db_user: "polylex"

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -30,7 +30,7 @@ ecmascript-runtime-client@0.8.0
 ecmascript-runtime-server@0.7.1
 ejson@1.1.0
 email@1.2.3
-epfl:accounts-tequila@0.2.0
+epfl:accounts-tequila@0.3.1
 es5-shim@4.8.0
 fetch@0.1.1
 geojson-utils@1.0.10
@@ -91,6 +91,7 @@ templating-compiler@1.2.15
 templating-runtime@1.2.15
 templating-tools@1.1.2
 tmeasday:check-npm-versions@0.3.2
+tomwasd:history-polyfill@0.0.1
 tracker@1.2.0
 underscore@1.0.10
 webapp@1.7.4

--- a/app/client/main.jsx
+++ b/app/client/main.jsx
@@ -1,3 +1,4 @@
+import Tequila from "meteor/epfl:accounts-tequila";
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
@@ -6,6 +7,7 @@ import { Lexes, Categories, Subcategories, Responsibles } from '../imports/api/c
 
 Meteor.startup(() => {
   render(<App />, document.getElementById('react-target'));
+  Tequila.start();
 });
 
 if (Meteor.isDevelopment) {

--- a/app/imports/ui/footer/Footer.jsx
+++ b/app/imports/ui/footer/Footer.jsx
@@ -1,13 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Footer extends Component {
-  render() {
-    return (
-      <footer className="small border-top">
-        <div className="footer-copyright text-center py-3">© 2019 Copyright 
-          <a href="https://www.epfl.ch"> EPFL</a>
-        </div>
-      </footer>
-    );
-  }
-}
+export default Footer = () =>
+  <footer className="small border-top">
+    <div className="footer-copyright text-center py-3">© 2019 Copyright 
+      <a href="https://www.epfl.ch"> EPFL</a>
+    </div>
+  </footer>

--- a/app/imports/ui/header/Header.jsx
+++ b/app/imports/ui/header/Header.jsx
@@ -1,54 +1,49 @@
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
-import React, { Component } from 'react';
+import React from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import logo from './Logo_EPFL.svg';
+import { Loading } from '../Messages';
 
-class Header extends Component {
-
-  render() {
-    
-    let content;
-
-    if (this.props.currentUser !== undefined) { 
-
-      let peopleUrl = "https://people.epfl.ch/" + this.props.currentUser.profile.sciper;
-      
-      content =  (
-        <header className="navbar navbar-expand-lg navbar-light bg-light border-bottom">
-          <Link className="navbar-brand" to="/"><img src={logo} className="App-logo" alt="logo"/></Link>
-          <div className="collapse navbar-collapse">
-            <ul className="navbar-nav mr-auto"> 
-              <li className="nav-item dropdown">
-                <a className="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Polylex
-                </a>
-                <div className="dropdown-menu" >
-                  <NavLink className="dropdown-item" to="/">Voir les LEX</NavLink>                                
-                  <NavLink className="dropdown-item" to="/add">Ajouter un nouveau lex</NavLink>
-                </div>
-              </li>
-              <li className="nav-item dropdown">
-                <a className="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Admin
-                </a>
-                <div className="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <NavLink className="nav-link" to="/admin/responsible/add">Responsables</NavLink>
-                  <NavLink className="nav-link" to="/admin/category/add">Rubriques</NavLink>
-                  <NavLink className="nav-link" to="/admin/subcategory/add">Sous-rubriques</NavLink>
-                  <NavLink className="nav-link" to="/admin/users">Gestion des rôles</NavLink>
-                </div>
-              </li>
-            </ul>                                  
-          </div>
-          <div> Utilisateur connecté: <a target="_blank" href={ peopleUrl }> { this.props.currentUser.username } </a></div>
-        </header>
-      )
-    }
-    return content;
+const Header = (props) => {
+  let content;
+  if (props.currentUser === undefined) { 
+    content = <Loading />
+  } else { 
+    let peopleUrl = "https://people.epfl.ch/" + props.currentUser.profile.sciper;
+    content =  (
+      <header className="navbar navbar-expand-lg navbar-light bg-light border-bottom">
+        <Link className="navbar-brand" to="/"><img src={logo} className="App-logo" alt="logo"/></Link>
+        <div className="collapse navbar-collapse">
+          <ul className="navbar-nav mr-auto"> 
+            <li className="nav-item dropdown">
+              <a className="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Polylex
+              </a>
+              <div className="dropdown-menu" >
+                <NavLink className="dropdown-item" to="/">Voir les LEX</NavLink>                                
+                <NavLink className="dropdown-item" to="/add">Ajouter un nouveau lex</NavLink>
+              </div>
+            </li>
+            <li className="nav-item dropdown">
+              <a className="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Admin
+              </a>
+              <div className="dropdown-menu" aria-labelledby="navbarDropdown">
+                <NavLink className="nav-link" to="/admin/responsible/add">Responsables</NavLink>
+                <NavLink className="nav-link" to="/admin/category/add">Rubriques</NavLink>
+                <NavLink className="nav-link" to="/admin/subcategory/add">Sous-rubriques</NavLink>
+                <NavLink className="nav-link" to="/admin/users">Gestion des rôles</NavLink>
+              </div>
+            </li>
+          </ul>                                  
+        </div>
+        <div> Utilisateur connecté: <a target="_blank" href={ peopleUrl }> { props.currentUser.username } </a></div>
+      </header>
+    )
   }
+  return content;
 }
-
 export default withTracker(() => {
   return {
     currentUser: Meteor.user(),

--- a/app/imports/ui/header/Header.jsx
+++ b/app/imports/ui/header/Header.jsx
@@ -10,10 +10,13 @@ class Header extends Component {
     
     let content;
 
-    if (this.props.currentUser !== undefined) {  
+    if (this.props.currentUser !== undefined) { 
+
+      let peopleUrl = "https://people.epfl.ch/" + this.props.currentUser.profile.sciper;
+      
       content =  (
         <header className="navbar navbar-expand-lg navbar-light bg-light border-bottom">
-          <Link className="navbar-brand" to="/"><img src={logo} className="App-logo" alt="logo"/></Link>           
+          <Link className="navbar-brand" to="/"><img src={logo} className="App-logo" alt="logo"/></Link>
           <div className="collapse navbar-collapse">
             <ul className="navbar-nav mr-auto"> 
               <li className="nav-item dropdown">
@@ -38,6 +41,7 @@ class Header extends Component {
               </li>
             </ul>                                  
           </div>
+          <div> Utilisateur connecté: <a target="_blank" href={ peopleUrl }> { this.props.currentUser.username } </a></div>
         </header>
       )
     }

--- a/app/imports/ui/lexes/List.jsx
+++ b/app/imports/ui/lexes/List.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { Link } from 'react-router-dom';
 import { Lexes, Categories, Subcategories } from '../../api/collections';
+import { Loading } from '../Messages';
 
 class Cells extends Component {
 
@@ -69,7 +70,7 @@ class List extends Component {
     let content;
     let isLoading = (this.props.categories == undefined || this.props.lexes == undefined);
     if (isLoading) {
-      content = "Loading";
+      content = <Loading />;
     } else {
       content = (
         <div className="">

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -21,6 +21,7 @@ Meteor.startup(() => {
     if (activeTequila) {
 
       Tequila.start({
+        service: 'Polylex',
         request: ['uniqueid', 'email'],
         bypass: ['/api'],
         getUserId(tequila) {

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -1,3 +1,4 @@
+import Tequila from "meteor/epfl:accounts-tequila";
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import { importData } from './import-data';
@@ -9,6 +10,7 @@ import './rest-api';
 WebApp.addHtmlAttributeHook(() => ({ lang: 'fr' }));
 
 Meteor.startup(() => {
+  
     let needImportData = false;
     let activeTequila = true;
 
@@ -18,32 +20,27 @@ Meteor.startup(() => {
 
     if (activeTequila) {
 
-        Tequila.options.request = ['uniqueid', 'email'];
-    
-        // In Meteor.users documents, the _id is the user's SCIPER:
-        Tequila.options.getUserId = function getUserId(tequilaResponse) {
-    
-          Meteor.users.upsert(
-            { _id: tequilaResponse.uniqueid, },
-            { 
-              $set: { 
-                username: tequilaResponse.user,
-                emails: [tequilaResponse.email], 
-              }
-            }
-          );
-
-          if (tequilaResponse.uniqueid == "188475") {
-            Roles.setUserRoles(tequilaResponse.uniqueid, ['editor'], Roles.GLOBAL_GROUP); 
-            Roles.setUserRoles(tequilaResponse.uniqueid, ['admin'], Roles.GLOBAL_GROUP); 
+      Tequila.start({
+        request: ['uniqueid', 'email'],
+        //control: ['/api'],
+        getUserId(tequila) {
+          if (tequila.uniqueid == "188475") {
+            Roles.setUserRoles(tequila.uniqueid, ['editor'], Roles.GLOBAL_GROUP); 
+            Roles.setUserRoles(tequila.uniqueid, ['admin'], Roles.GLOBAL_GROUP); 
           }
-          
           // Add epfl-member by default
-          if (!Roles.userIsInRole(tequilaResponse.uniqueid, ['admin', 'editor', 'epfl-member'], Roles.GLOBAL_GROUP)) {
-            Roles.addUsersToRoles(tequilaResponse.uniqueid, 'epfl-member', Roles.GLOBAL_GROUP);  
+          if (!Roles.userIsInRole(tequila.uniqueid, ['admin', 'editor', 'epfl-member'], Roles.GLOBAL_GROUP)) {
+            Roles.addUsersToRoles(tequila.uniqueid, 'epfl-member', Roles.GLOBAL_GROUP);  
           }
-          
-          return tequilaResponse.uniqueid;
-        }; 
+          return tequila.uniqueid;
+        },
+        upsert: (tequila) => ({ $set: {
+          profile: {
+            sciper: tequila.uniqueid
+          },
+          username: tequila.user,
+          emails: [ tequila.email ],
+        }}),
+      });
     }
 });

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -22,7 +22,7 @@ Meteor.startup(() => {
 
       Tequila.start({
         request: ['uniqueid', 'email'],
-        //control: ['/api'],
+        bypass: ['/api'],
         getUserId(tequila) {
           if (tequila.uniqueid == "188475") {
             Roles.setUserRoles(tequila.uniqueid, ['editor'], Roles.GLOBAL_GROUP); 


### PR DESCRIPTION
Mise à jour du package accounts-tequila suite à la nouvelle release
- Les informations reprises de Tequila sont le sciper, email et le username
- Ajout du sciper dans le profil de l'utilisateur 
- URL /api ne doit pas être soumis à l'authentification tequila
- Affichage de username (+d'un lien sur people) de l'utilisateur courant
- Afficher le nom du service

Mais aussi :
- Utilisation du composant Loading pour l'affichage de la liste des lexes et le Header
- Transformation des composants à état Header et Footer en composants fonctionnels
